### PR TITLE
Adding in Show Player Names option on map

### DIFF
--- a/src/app/components/Settings/Settings.tsx
+++ b/src/app/components/Settings/Settings.tsx
@@ -74,6 +74,7 @@ function Settings(): JSX.Element {
           onChange={(event) => setShowPlayerNames(event.target.checked)}
         />
       </label>
+      <label className={styles.label}>
         Always show direction
         <input
           type="checkbox"

--- a/src/app/components/Settings/Settings.tsx
+++ b/src/app/components/Settings/Settings.tsx
@@ -13,6 +13,8 @@ function Settings(): JSX.Element {
     setMaxTraceLines,
     showTraceLines,
     setShowTraceLines,
+    showPlayerNames,
+    setShowPlayerNames,
   } = useSettings();
 
   return (
@@ -60,6 +62,14 @@ function Settings(): JSX.Element {
           type="number"
           value={maxTraceLines}
           onChange={(event) => setMaxTraceLines(+event.target.value)}
+        />
+      </label>
+      <label className={styles.label}>
+        Show Player Names
+        <input
+          type="checkbox"
+          checked={showPlayerNames}
+          onChange={(event) => setShowPlayerNames(event.target.checked)}
         />
       </label>
     </div>

--- a/src/app/components/WorldMap/useGroupPositions.ts
+++ b/src/app/components/WorldMap/useGroupPositions.ts
@@ -17,6 +17,21 @@ function useGroupPositions(group: Group): void {
     if (!latestLeafletMap) {
       return;
     }
+
+    const groupValues = Object.values(group);
+    Object.values(playerMarkers).forEach((marker, index) => {
+      marker.unbindTooltip();
+      marker.bindTooltip(groupValues[index].username!, {
+        direction: 'top',
+        permanent: showPlayerNames,
+      });
+    });
+  }, [showPlayerNames]);
+
+  useEffect(() => {
+    if (!latestLeafletMap) {
+      return;
+    }
     const removeablePlayerMarkers = { ...playerMarkers };
 
     const newPlayerMarkers = Object.values(group)
@@ -28,24 +43,23 @@ function useGroupPositions(group: Group): void {
           delete removeablePlayerMarkers[username];
           const existingMarker = playerMarkers[username];
           let marker: leaflet.Marker = playerMarkers[username];
+
           if (!existingMarker) {
             marker = leaflet.marker(player.position!.location, {
               icon,
               zIndexOffset: 8999,
               pmIgnore: true,
             });
-            marker.bindTooltip(username, { direction: 'top' });
+
+            marker.bindTooltip(username, {
+              direction: 'top',
+              permanent: showPlayerNames,
+            });
             marker.addTo(latestLeafletMap!);
             marker.getElement()!.classList.add('leaflet-player-marker');
           }
 
           marker.setLatLng(position.location);
-
-          if (showPlayerNames && !marker.isTooltipOpen()) {
-            marker.openTooltip();
-          } else if (!showPlayerNames && marker.isTooltipOpen()) {
-            marker.closeTooltip();
-          }
 
           const playerImage = marker.getElement()!;
           let rotation = position.rotation - 180;

--- a/src/app/components/WorldMap/useGroupPositions.ts
+++ b/src/app/components/WorldMap/useGroupPositions.ts
@@ -14,10 +14,6 @@ function useGroupPositions(group: Group): void {
   const { showPlayerNames } = useSettings();
 
   useEffect(() => {
-    if (!latestLeafletMap) {
-      return;
-    }
-
     const groupValues = Object.values(group);
     Object.values(playerMarkers).forEach((marker, index) => {
       marker.unbindTooltip();

--- a/src/app/components/WorldMap/useGroupPositions.ts
+++ b/src/app/components/WorldMap/useGroupPositions.ts
@@ -3,12 +3,15 @@ import { useEffect, useState } from 'react';
 import type { Group } from '../../utils/useReadLivePosition';
 import { LeafIcon } from './useLayerGroups';
 import { latestLeafletMap } from './useWorldMap';
+import { useSettings } from '../../contexts/SettingsContext';
 
 const icon = new LeafIcon({ iconUrl: '/player.webp' });
 function useGroupPositions(group: Group): void {
   const [playerMarkers, setPlayerMarkers] = useState<{
     [username: string]: leaflet.Marker;
   }>({});
+
+  const { showPlayerNames } = useSettings();
 
   useEffect(() => {
     if (!latestLeafletMap) {
@@ -37,6 +40,12 @@ function useGroupPositions(group: Group): void {
           }
 
           marker.setLatLng(position.location);
+
+          if (showPlayerNames && !marker.isTooltipOpen()) {
+            marker.openTooltip();
+          } else if (!showPlayerNames && marker.isTooltipOpen()) {
+            marker.closeTooltip();
+          }
 
           const playerImage = marker.getElement()!;
           let rotation = position.rotation - 180;

--- a/src/app/contexts/SettingsContext.tsx
+++ b/src/app/contexts/SettingsContext.tsx
@@ -61,6 +61,8 @@ export function SettingsProvider({
   );
   const [showPlayerNames, setShowPlayerNames] = usePersistentState(
     'show-player-names',
+    false
+  );
   const [alwaysShowDirection, setAlwaysShowDirection] = usePersistentState(
     'always-show-direction',
     false

--- a/src/app/contexts/SettingsContext.tsx
+++ b/src/app/contexts/SettingsContext.tsx
@@ -14,6 +14,8 @@ type SettingsContextValue = {
   setMaxTraceLines: (maxTraceLines: number) => void;
   showTraceLines: boolean;
   setShowTraceLines: (showTraceLines: boolean) => void;
+  showPlayerNames: boolean;
+  setShowPlayerNames: (showPlayerName: boolean) => void;
 };
 const SettingsContext = createContext<SettingsContextValue>({
   markerSize: 30,
@@ -26,6 +28,8 @@ const SettingsContext = createContext<SettingsContextValue>({
   setMaxTraceLines: () => undefined,
   showTraceLines: false,
   setShowTraceLines: () => undefined,
+  showPlayerNames: false,
+  setShowPlayerNames: () => undefined,
 });
 
 type SettingsProviderProps = {
@@ -51,6 +55,10 @@ export function SettingsProvider({
     'max-trace-lines',
     250
   );
+  const [showPlayerNames, setShowPlayerNames] = usePersistentState(
+    'show-player-names',
+    false
+  );
 
   return (
     <SettingsContext.Provider
@@ -65,6 +73,8 @@ export function SettingsProvider({
         setMaxTraceLines,
         showTraceLines,
         setShowTraceLines,
+        showPlayerNames,
+        setShowPlayerNames,
       }}
     >
       {children}


### PR DESCRIPTION
This adds in a new Setting that will make it so the tooltips above the players names will always display without having to hover. 