### PR TITLE
Add direction line and hotkeys

### DIFF
--- a/dist/overwolf/manifest.json
+++ b/dist/overwolf/manifest.json
@@ -138,10 +138,20 @@
         "action-type": "custom",
         "default": "F8"
       },
-      "show_hide_direction": {
-        "title": "Show/Hide Direction",
+      "zoom_in_map": {
+        "title": "Zoom In Map (Website)",
         "action-type": "custom",
         "default": "F9"
+      },
+      "zoom_out_map": {
+        "title": "Zoom Out Map (Website)",
+        "action-type": "custom",
+        "default": "F10"
+      },
+      "show_hide_direction": {
+        "title": "Show/Hide Direction (Website)",
+        "action-type": "custom",
+        "default": "F11"
       }
     },
     "protocol_override_domains": {

--- a/dist/overwolf/manifest.json
+++ b/dist/overwolf/manifest.json
@@ -137,6 +137,11 @@
         "title": "Zoom Out Minimap",
         "action-type": "custom",
         "default": "F8"
+      },
+      "show_hide_direction": {
+        "title": "Show/Hide Direction",
+        "action-type": "custom",
+        "default": "F9"
       }
     },
     "protocol_override_domains": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,8 @@ import { useState } from 'react';
 import type { MarkerBasic } from './contexts/MarkersContext';
 import UpsertArea from './components/UpsertArea/UpsertArea';
 import type { MarkerRouteItem } from './components/MarkerRoutes/MarkerRoutes';
+import useEventListener from './utils/useEventListener';
+import { latestLeafletMap } from './components/WorldMap/useWorldMap';
 
 function App(): JSX.Element {
   const [targetMarker, setTargetMarker] = useState<
@@ -16,6 +18,28 @@ function App(): JSX.Element {
   const [targetMarkerRoute, setTargetMarkerRoute] = useState<
     MarkerRouteItem | true | undefined
   >(undefined);
+
+  useEventListener(
+    'hotkey-zoom_in_map',
+    () => {
+      if (latestLeafletMap) {
+        const zoom = latestLeafletMap.getZoom();
+        latestLeafletMap.setZoom(Math.min(zoom + 1, 6));
+      }
+    },
+    []
+  );
+
+  useEventListener(
+    'hotkey-zoom_out_map',
+    () => {
+      if (latestLeafletMap) {
+        const zoom = latestLeafletMap.getZoom();
+        latestLeafletMap.setZoom(Math.max(zoom - 1, 0));
+      }
+    },
+    []
+  );
 
   return (
     <div className={styles.container}>

--- a/src/app/components/Settings/Settings.tsx
+++ b/src/app/components/Settings/Settings.tsx
@@ -13,6 +13,8 @@ function Settings(): JSX.Element {
     setMaxTraceLines,
     showTraceLines,
     setShowTraceLines,
+    alwaysShowDirection,
+    setAlwaysShowDirection,
   } = useSettings();
 
   return (
@@ -60,6 +62,14 @@ function Settings(): JSX.Element {
           type="number"
           value={maxTraceLines}
           onChange={(event) => setMaxTraceLines(+event.target.value)}
+        />
+      </label>
+      <label className={styles.label}>
+        Always show direction
+        <input
+          type="checkbox"
+          checked={alwaysShowDirection}
+          onChange={(event) => setAlwaysShowDirection(event.target.checked)}
         />
       </label>
     </div>

--- a/src/app/components/Settings/Settings.tsx
+++ b/src/app/components/Settings/Settings.tsx
@@ -72,6 +72,8 @@ function Settings(): JSX.Element {
           onChange={(event) => setAlwaysShowDirection(event.target.checked)}
         />
       </label>
+      <h3>Hotkeys</h3>
+      <em>Hotkeys are configured in the Overwolf app</em>
     </div>
   );
 }

--- a/src/app/components/WorldMap/useDirectionLine.ts
+++ b/src/app/components/WorldMap/useDirectionLine.ts
@@ -1,0 +1,41 @@
+import leaflet from 'leaflet';
+import { useEffect, useMemo } from 'react';
+import type { Position } from '../../contexts/PositionContext';
+import { useSettings } from '../../contexts/SettingsContext';
+import { latestLeafletMap } from './useWorldMap';
+
+function useDirectionLine(position: Position) {
+  const { alwaysShowDirection } = useSettings();
+
+  const directionLine = useMemo(
+    () =>
+      leaflet.polyline([], {
+        color: '#0EA2FE',
+        dashArray: '5',
+      }),
+    []
+  );
+
+  useEffect(() => {
+    if (alwaysShowDirection) {
+      directionLine.addTo(latestLeafletMap!);
+    }
+
+    return () => {
+      directionLine.remove();
+    };
+  }, [alwaysShowDirection]);
+
+  useEffect(() => {
+    const latLng: [number, number] = [
+      position.location[0] +
+        Math.sin((position.rotation * Math.PI) / 180) * 500,
+      position.location[1] +
+        Math.cos((position.rotation * Math.PI) / 180) * 500,
+    ];
+    const latLngs = [position.location, latLng];
+    directionLine.setLatLngs(latLngs);
+  }, [position]);
+}
+
+export default useDirectionLine;

--- a/src/app/components/WorldMap/useDirectionLine.ts
+++ b/src/app/components/WorldMap/useDirectionLine.ts
@@ -2,6 +2,7 @@ import leaflet from 'leaflet';
 import { useEffect, useMemo, useState } from 'react';
 import type { Position } from '../../contexts/PositionContext';
 import { useSettings } from '../../contexts/SettingsContext';
+import useEventListener from '../../utils/useEventListener';
 import { latestLeafletMap } from './useWorldMap';
 
 function useDirectionLine(position: Position) {
@@ -17,19 +18,13 @@ function useDirectionLine(position: Position) {
     []
   );
 
-  useEffect(() => {
-    function handleSessionExpired() {
+  useEventListener(
+    'hotkey-show_hide_direction',
+    () => {
       setShowDirection((showDirection) => !showDirection);
-    }
-    window.addEventListener('hotkey-show_hide_direction', handleSessionExpired);
-
-    return () => {
-      window.removeEventListener(
-        'hotkey-show_hide_direction',
-        handleSessionExpired
-      );
-    };
-  }, [showDirection]);
+    },
+    [showDirection]
+  );
 
   useEffect(() => {
     if (showDirection || alwaysShowDirection) {

--- a/src/app/components/WorldMap/useDirectionLine.ts
+++ b/src/app/components/WorldMap/useDirectionLine.ts
@@ -1,11 +1,12 @@
 import leaflet from 'leaflet';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { Position } from '../../contexts/PositionContext';
 import { useSettings } from '../../contexts/SettingsContext';
 import { latestLeafletMap } from './useWorldMap';
 
 function useDirectionLine(position: Position) {
   const { alwaysShowDirection } = useSettings();
+  const [showDirection, setShowDirection] = useState(false);
 
   const directionLine = useMemo(
     () =>
@@ -17,14 +18,28 @@ function useDirectionLine(position: Position) {
   );
 
   useEffect(() => {
-    if (alwaysShowDirection) {
+    function handleSessionExpired() {
+      setShowDirection((showDirection) => !showDirection);
+    }
+    window.addEventListener('hotkey-show_hide_direction', handleSessionExpired);
+
+    return () => {
+      window.removeEventListener(
+        'hotkey-show_hide_direction',
+        handleSessionExpired
+      );
+    };
+  }, [showDirection]);
+
+  useEffect(() => {
+    if (showDirection || alwaysShowDirection) {
       directionLine.addTo(latestLeafletMap!);
     }
 
     return () => {
       directionLine.remove();
     };
-  }, [alwaysShowDirection]);
+  }, [showDirection, alwaysShowDirection]);
 
   useEffect(() => {
     const latLng: [number, number] = [

--- a/src/app/components/WorldMap/usePlayerPosition.ts
+++ b/src/app/components/WorldMap/usePlayerPosition.ts
@@ -5,6 +5,7 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { isOverwolfApp } from '../../utils/overwolf';
 import type CanvasMarker from './CanvasMarker';
 import { updateRotation } from './rotation';
+import useDirectionLine from './useDirectionLine';
 import { LeafIcon } from './useLayerGroups';
 
 const divElement = leaflet.DomUtil.create('div', 'leaflet-player-position');
@@ -40,6 +41,8 @@ function usePlayerPosition({
   const traceDots = useMemo<leaflet.Circle[]>(() => [], []);
 
   const { showTraceLines, maxTraceLines } = useSettings();
+
+  useDirectionLine(position);
 
   useEffect(() => {
     if (!leafletMap) {

--- a/src/app/contexts/SettingsContext.tsx
+++ b/src/app/contexts/SettingsContext.tsx
@@ -14,6 +14,8 @@ type SettingsContextValue = {
   setMaxTraceLines: (maxTraceLines: number) => void;
   showTraceLines: boolean;
   setShowTraceLines: (showTraceLines: boolean) => void;
+  alwaysShowDirection: boolean;
+  setAlwaysShowDirection: (alwaysShowDirection: boolean) => void;
 };
 const SettingsContext = createContext<SettingsContextValue>({
   markerSize: 30,
@@ -26,6 +28,8 @@ const SettingsContext = createContext<SettingsContextValue>({
   setMaxTraceLines: () => undefined,
   showTraceLines: false,
   setShowTraceLines: () => undefined,
+  alwaysShowDirection: false,
+  setAlwaysShowDirection: () => undefined,
 });
 
 type SettingsProviderProps = {
@@ -51,6 +55,10 @@ export function SettingsProvider({
     'max-trace-lines',
     250
   );
+  const [alwaysShowDirection, setAlwaysShowDirection] = usePersistentState(
+    'always-show-direction',
+    false
+  );
 
   return (
     <SettingsContext.Provider
@@ -65,6 +73,8 @@ export function SettingsProvider({
         setMaxTraceLines,
         showTraceLines,
         setShowTraceLines,
+        alwaysShowDirection,
+        setAlwaysShowDirection,
       }}
     >
       {children}

--- a/src/app/contexts/UserContext.tsx
+++ b/src/app/contexts/UserContext.tsx
@@ -5,6 +5,7 @@ import { fetchJSON } from '../utils/api';
 import { writeError, writeWarn } from '../utils/logs';
 import { notify } from '../utils/notifications';
 import { usePersistentState } from '../utils/storage';
+import useEventListener from '../utils/useEventListener';
 
 export type User = {
   _id: string;
@@ -99,17 +100,14 @@ export function UserProvider({ children }: UserProviderProps): JSX.Element {
     }
   };
 
-  useEffect(() => {
-    function handleSessionExpired() {
+  useEventListener(
+    'session-expired',
+    () => {
       setAccount(null);
       writeWarn('Session expired');
-    }
-    window.addEventListener('session-expired', handleSessionExpired);
-
-    return () => {
-      window.removeEventListener('session-expired', handleSessionExpired);
-    };
-  }, []);
+    },
+    []
+  );
 
   useEffect(() => {
     if (username) {

--- a/src/app/minimap.tsx
+++ b/src/app/minimap.tsx
@@ -19,6 +19,8 @@ import { SettingsProvider } from './contexts/SettingsContext';
 import { classNames } from './utils/styles';
 import ResizeBorder from './components/ResizeBorder/ResizeBorder';
 import useReadLivePosition from './utils/useReadLivePosition';
+import useEventListener from './utils/useEventListener';
+import { latestLeafletMap } from './components/WorldMap/useWorldMap';
 
 function Minimap(): JSX.Element {
   const [showSetup, setShowSetup] = useState(false);
@@ -39,6 +41,27 @@ function Minimap(): JSX.Element {
   if (!isOverwolfApp) {
     useReadLivePosition();
   }
+
+  useEventListener(
+    'hotkey-zoom_in_minimap',
+    () => {
+      if (latestLeafletMap) {
+        const zoom = latestLeafletMap.getZoom();
+        latestLeafletMap.setZoom(Math.min(zoom + 1, 6));
+      }
+    },
+    []
+  );
+  useEventListener(
+    'hotkey-zoom_out_minimap',
+    () => {
+      if (latestLeafletMap) {
+        const zoom = latestLeafletMap.getZoom();
+        latestLeafletMap.setZoom(Math.max(zoom - 1, 0));
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     if (!isHovering) {

--- a/src/app/sender/Settings.tsx
+++ b/src/app/sender/Settings.tsx
@@ -4,6 +4,7 @@ import { useSettings } from '../contexts/SettingsContext';
 import { useAccount } from '../contexts/UserContext';
 import {
   SETUP_MINIMAP,
+  SHOW_HIDE_DIRECTION,
   SHOW_HIDE_APP,
   SHOW_HIDE_MINIMAP,
   useHotkeyBinding,
@@ -23,6 +24,7 @@ function Settings({ onClose }: SettingsProps): JSX.Element {
   const showHideMinimapBinding = useHotkeyBinding(SHOW_HIDE_MINIMAP);
   const zoomInMinimapBinding = useHotkeyBinding(ZOOM_IN_MINIMAP);
   const zoomOutMinimapBinding = useHotkeyBinding(ZOOM_OUT_MINIMAP);
+  const showHideDirectionBinding = useHotkeyBinding(SHOW_HIDE_DIRECTION);
   const [showMinimap, setShowMinimap] = useMinimap();
 
   const { logoutAccount } = useAccount();
@@ -36,7 +38,7 @@ function Settings({ onClose }: SettingsProps): JSX.Element {
       <div className={styles.settings}>
         <h4>Minimap</h4>
         <label className={styles.label}>
-          Show blank minimap
+          Show blank Minimap
           <input
             type="checkbox"
             checked={showMinimap}
@@ -59,25 +61,31 @@ function Settings({ onClose }: SettingsProps): JSX.Element {
           </a>
         </label>
         <label className={styles.label}>
-          Setup minimap
+          Setup Minimap
           <a href="overwolf://settings/games-overlay?hotkey=setup_minimap&gameId=21816">
             {setupMinimapBinding}
           </a>
         </label>
         <label className={styles.label}>
-          Show/Hide minimap
+          Show/Hide Minimap
           <a href="overwolf://settings/games-overlay?hotkey=show_hide_minimap&gameId=21816">
             {showHideMinimapBinding}
           </a>
         </label>
         <label className={styles.label}>
-          Zoom in minimap
+          Show/Hide Direction
+          <a href="overwolf://settings/games-overlay?hotkey=show_hide_direction&gameId=21816">
+            {showHideDirectionBinding}
+          </a>
+        </label>
+        <label className={styles.label}>
+          Zoom in Minimap
           <a href="overwolf://settings/games-overlay?hotkey=zoom_in_minimap&gameId=21816">
             {zoomInMinimapBinding}
           </a>
         </label>
         <label className={styles.label}>
-          Zoom out minimap
+          Zoom out Minimap
           <a href="overwolf://settings/games-overlay?hotkey=zoom_out_minimap&gameId=21816">
             {zoomOutMinimapBinding}
           </a>

--- a/src/app/sender/Settings.tsx
+++ b/src/app/sender/Settings.tsx
@@ -10,6 +10,8 @@ import {
   useHotkeyBinding,
   ZOOM_IN_MINIMAP,
   ZOOM_OUT_MINIMAP,
+  ZOOM_IN_MAP,
+  ZOOM_OUT_MAP,
 } from '../utils/hotkeys';
 import styles from './Settings.module.css';
 
@@ -25,6 +27,8 @@ function Settings({ onClose }: SettingsProps): JSX.Element {
   const zoomInMinimapBinding = useHotkeyBinding(ZOOM_IN_MINIMAP);
   const zoomOutMinimapBinding = useHotkeyBinding(ZOOM_OUT_MINIMAP);
   const showHideDirectionBinding = useHotkeyBinding(SHOW_HIDE_DIRECTION);
+  const zoomInMapBinding = useHotkeyBinding(ZOOM_IN_MAP);
+  const zoomOutMapBinding = useHotkeyBinding(ZOOM_OUT_MAP);
   const [showMinimap, setShowMinimap] = useMinimap();
 
   const { logoutAccount } = useAccount();
@@ -53,7 +57,26 @@ function Settings({ onClose }: SettingsProps): JSX.Element {
             onChange={(event) => setShowRegionBorders(event.target.checked)}
           />
         </label>
-        <h4>Hotkeys</h4>
+        <h4>Website Hotkeys</h4>
+        <label className={styles.label}>
+          Zoom in Map
+          <a href="overwolf://settings/games-overlay?hotkey=zoom_in_map&gameId=21816">
+            {zoomInMapBinding}
+          </a>
+        </label>
+        <label className={styles.label}>
+          Zoom out Map
+          <a href="overwolf://settings/games-overlay?hotkey=zoom_out_map&gameId=21816">
+            {zoomOutMapBinding}
+          </a>
+        </label>
+        <label className={styles.label}>
+          Show/Hide Direction
+          <a href="overwolf://settings/games-overlay?hotkey=show_hide_direction&gameId=21816">
+            {showHideDirectionBinding}
+          </a>
+        </label>
+        <h4>App Hotkeys</h4>
         <label className={styles.label}>
           Show/Hide App
           <a href="overwolf://settings/games-overlay?hotkey=show_hide_app&gameId=21816">
@@ -70,12 +93,6 @@ function Settings({ onClose }: SettingsProps): JSX.Element {
           Show/Hide Minimap
           <a href="overwolf://settings/games-overlay?hotkey=show_hide_minimap&gameId=21816">
             {showHideMinimapBinding}
-          </a>
-        </label>
-        <label className={styles.label}>
-          Show/Hide Direction
-          <a href="overwolf://settings/games-overlay?hotkey=show_hide_direction&gameId=21816">
-            {showHideDirectionBinding}
           </a>
         </label>
         <label className={styles.label}>

--- a/src/app/sender/useShareHotkeys.ts
+++ b/src/app/sender/useShareHotkeys.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import type { Socket } from 'socket.io-client';
+import type { DefaultEventsMap } from 'socket.io/dist/typed-events';
+
+function useShareHotkeys(
+  socket: Socket<DefaultEventsMap, DefaultEventsMap> | null
+) {
+  useEffect(() => {
+    if (!socket) {
+      return;
+    }
+    async function handleHotkeyPressed(
+      event: overwolf.settings.hotkeys.OnPressedEvent
+    ) {
+      socket!.emit('hotkey', event.name);
+    }
+    overwolf.settings.hotkeys.onPressed.addListener(handleHotkeyPressed);
+    return () => {
+      overwolf.settings.hotkeys.onPressed.removeListener(handleHotkeyPressed);
+    };
+  }, [socket]);
+}
+
+export default useShareHotkeys;

--- a/src/app/sender/useShareLivePosition.ts
+++ b/src/app/sender/useShareLivePosition.ts
@@ -7,6 +7,7 @@ import { usePosition } from '../contexts/PositionContext';
 import { usePersistentState } from '../utils/storage';
 import { toast } from 'react-toastify';
 import type { Group } from '../utils/useReadLivePosition';
+import useShareHotkeys from './useShareHotkeys';
 
 const { VITE_SOCKET_ENDPOINT } = import.meta.env;
 
@@ -28,6 +29,8 @@ function useShareLivePosition(token: string) {
   const user = useUser();
   const { position } = usePosition();
   const { account } = useAccount();
+
+  useShareHotkeys(socket);
 
   useEffect(() => {
     if (!token || !isSharing) {

--- a/src/app/utils/hotkeys.ts
+++ b/src/app/utils/hotkeys.ts
@@ -6,6 +6,8 @@ export const SETUP_MINIMAP = 'setup_minimap';
 export const SHOW_HIDE_MINIMAP = 'show_hide_minimap';
 export const ZOOM_IN_MINIMAP = 'zoom_in_minimap';
 export const ZOOM_OUT_MINIMAP = 'zoom_out_minimap';
+export const ZOOM_IN_MAP = 'zoom_in_map';
+export const ZOOM_OUT_MAP = 'zoom_out_map';
 export const SHOW_HIDE_DIRECTION = 'show_hide_direction';
 
 export function useHotkeyBinding(name: string): string {

--- a/src/app/utils/hotkeys.ts
+++ b/src/app/utils/hotkeys.ts
@@ -6,6 +6,7 @@ export const SETUP_MINIMAP = 'setup_minimap';
 export const SHOW_HIDE_MINIMAP = 'show_hide_minimap';
 export const ZOOM_IN_MINIMAP = 'zoom_in_minimap';
 export const ZOOM_OUT_MINIMAP = 'zoom_out_minimap';
+export const SHOW_HIDE_DIRECTION = 'show_hide_direction';
 
 export function useHotkeyBinding(name: string): string {
   const [hotkeyBinding, setHotkeyBinding] = useState<string>('');

--- a/src/app/utils/useEventListener.ts
+++ b/src/app/utils/useEventListener.ts
@@ -1,0 +1,18 @@
+import type { DependencyList } from 'react';
+import { useEffect } from 'react';
+
+function useEventListener(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  deps: DependencyList
+) {
+  useEffect(() => {
+    window.addEventListener(type, listener);
+
+    return () => {
+      window.removeEventListener(type, listener);
+    };
+  }, deps);
+}
+
+export default useEventListener;

--- a/src/app/utils/useReadLivePosition.ts
+++ b/src/app/utils/useReadLivePosition.ts
@@ -78,6 +78,15 @@ function useReadLivePosition(): [
     socket.emit('status', updateStatus);
     socket.on('update', updateStatus);
 
+    const handleHotkey = (steamId: string, hotkey: string) => {
+      if (steamId !== account?.steamId) {
+        return;
+      }
+      const event = new CustomEvent(`hotkey-${hotkey}`);
+      window.dispatchEvent(event);
+    };
+    socket.on('hotkey', handleHotkey);
+
     socket.on('connect', () => {
       if (socket.connected) {
         toast.success('Sharing live status 👌');
@@ -87,6 +96,8 @@ function useReadLivePosition(): [
     return () => {
       socket.off('connect');
       socket.off('update');
+      socket.off('hotkey');
+
       socket.close();
       setGroup({});
       toast.info('Stop sharing live status 🛑');

--- a/src/lib/live/socket.ts
+++ b/src/lib/live/socket.ts
@@ -80,6 +80,10 @@ export function initSocket(server: http.Server) {
       io!.to(token).emit('update', activePlayers[token]);
     });
 
+    client.on('hotkey', (hotkey) => {
+      io!.to(token).emit('hotkey', steamId, hotkey);
+    });
+
     client.on('disconnect', () => {
       if (!isOverwolfApp) {
         client.to(token).emit('disconnected', isOverwolfApp, steamName);


### PR DESCRIPTION
Fixes #39
Fixes #57

A direction line is added to see, in which direction you'll go if you go in a straight line (useful for autowalk).
You can toggle it with `F11` (default) in game if you have the Overwolf app connected with the website and logged in with Steam.
You can make it always visible in the settings.

Hotkeys to zoom in/out the minimap and big map are added. Again, it's required to use the same Steam login in the app and website.
Default hotkeys are `F9` (Zoom In) and `F10` (Zoom out).

https://user-images.githubusercontent.com/10058950/145551396-6cd69918-545a-4e82-bab9-f744859e9fc3.mp4

