### PR TITLE
Fix issue where required glyph field would not populate when editing …

### DIFF
--- a/packages/ui/components/AddResources/AddResources.tsx
+++ b/packages/ui/components/AddResources/AddResources.tsx
@@ -107,6 +107,9 @@ function AddResources({ marker, onClose }: AddResourcesProps): JSX.Element {
     if (filter.hasHP) {
       details.hp = marker?.hp || 0;
     }
+    if (filter.glyph) {
+      details.requiredGlyphId = marker?.requiredGlyphId;
+    }
     details.screenshotFilename = marker?.screenshotFilename;
     setDetails(details);
   }, [filter]);

--- a/packages/ui/components/AddResources/Details/Select/SelectGlyphType.tsx
+++ b/packages/ui/components/AddResources/Details/Select/SelectGlyphType.tsx
@@ -21,7 +21,8 @@ function SelectGlyphType({
   onChange,
   isRequired,
 }: SelectGlyphTypeIsRequired): JSX.Element {
-  const [glyph, setGlyph] = useState<Glyph | null>(() => null);
+  const glyph =
+    details && glyphs.find((glyph) => glyph.id === details.requiredGlyphId);
   const [search, setSearch] = useState('');
   const [isFocus, setIsFocus] = useState(false);
 
@@ -36,7 +37,6 @@ function SelectGlyphType({
       ...details,
       requiredGlyphId: glyph?.id,
     });
-    setGlyph(glyph);
   };
 
   const GlyphLabel = 'Glyph ' + (isRequired ? '(required)' : '(optional)');

--- a/packages/ui/components/AddResources/api.ts
+++ b/packages/ui/components/AddResources/api.ts
@@ -14,6 +14,7 @@ export type MarkerDTO = {
   size?: MarkerSize;
   customRespawnTimer?: number;
   hp?: number;
+  requiredGlyphId?: number;
   description?: string;
   screenshotFilename?: string;
   screenshotId?: string;


### PR DESCRIPTION
Fix an issue that was causing SelectGlyphType to rerender more than necessary, and result in glyph type field being empty when trying to edit a node.