### PR TITLE
Fix screenshot save bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ dist
 /data
 .turbo
 .vercel
+
+# IntelliJ Files
+*.iml
+.idea/

--- a/apps/api/src/lib/markers/router.ts
+++ b/apps/api/src/lib/markers/router.ts
@@ -426,6 +426,7 @@ async function bodyToMarker(
     size,
     description,
     screenshotId,
+    screenshotFilename,
     customRespawnTimer,
     hp,
     requiredGlyphId,
@@ -481,7 +482,10 @@ async function bodyToMarker(
   if (description) {
     marker.description = description.substring(0, MAX_DESCRIPTION_LENGTH);
   }
-  if (ObjectId.isValid(screenshotId)) {
+
+  if (screenshotFilename) {
+    marker.screenshotFilename = screenshotFilename;
+  } else if (ObjectId.isValid(screenshotId)) {
     const screenshot = await getScreenshotsCollection().findOne({
       _id: new ObjectId(screenshotId),
     });


### PR DESCRIPTION
Addressing issue when editing nodes with screenshots.

Currently the api server doesn't consume the screenshotFilename, if try to save a node with an existing screenshot it doesn't recognise the existing screenshot and it wrongly gets deleted.

Applied fix to correctly consume and recognise screenshotFilename when updating a node.