### PR TITLE
[Fix] Saving empty description on node edit doesn't persist

### DIFF
--- a/apps/api/src/lib/markers/router.ts
+++ b/apps/api/src/lib/markers/router.ts
@@ -200,7 +200,9 @@ markersRouter.patch(
       if (!mapFilter.hasHP) {
         unset.hp = 1;
       }
-
+      if (!marker.description) {
+        unset.description = 1;
+      }
       const oldMarker = await getMarkersCollection().findOne(query);
       if (
         oldMarker?.screenshotFilename &&
@@ -479,8 +481,8 @@ async function bodyToMarker(
     marker.requiredGlyphId = requiredGlyphId;
   }
 
-  if (description?.length >= 0) {
-    marker.description = description?.substring(0, MAX_DESCRIPTION_LENGTH);
+  if (description) {
+    marker.description = description.substring(0, MAX_DESCRIPTION_LENGTH);
   }
 
   if (screenshotFilename) {

--- a/apps/api/src/lib/markers/router.ts
+++ b/apps/api/src/lib/markers/router.ts
@@ -479,8 +479,8 @@ async function bodyToMarker(
     marker.requiredGlyphId = requiredGlyphId;
   }
 
-  if (description) {
-    marker.description = description.substring(0, MAX_DESCRIPTION_LENGTH);
+  if (description?.length >= 0) {
+    marker.description = description?.substring(0, MAX_DESCRIPTION_LENGTH);
   }
 
   if (screenshotFilename) {


### PR DESCRIPTION
Fixing bug where the description does not persist correctly in the api server when try to remove existing description from an existing node.

Example:
1. Create node with a description 'abc'.
2. Edit node to have empty description & save.
3. Observe node with original description 'abc'. 