### PR TITLE
Implement new setting to configure player icon colour

### DIFF
--- a/apps/overwolf/src/components/Settings/Settings.tsx
+++ b/apps/overwolf/src/components/Settings/Settings.tsx
@@ -19,6 +19,7 @@ import {
   Box,
   Button,
   Checkbox,
+  ColorInput,
   Group,
   Input,
   Kbd,
@@ -41,6 +42,8 @@ function Settings({ showMinimap, onShowMinimap }: SettingsProps): JSX.Element {
     setPeerToPeer,
     ocr,
     setOCR,
+    playerIconColor,
+    setPlayerIconColor,
   } = useSettings();
   const showHideAppBinding = useHotkeyBinding(SHOW_HIDE_APP);
   const setupMinimapBinding = useHotkeyBinding(SETUP_MINIMAP);
@@ -84,6 +87,11 @@ function Settings({ showMinimap, onShowMinimap }: SettingsProps): JSX.Element {
             checked={showRegionBorders}
             description="You'll see thin lines on the map which indicates the regions."
             onChange={(event) => setShowRegionBorders(event.target.checked)}
+          />
+          <ColorInput
+            label="Player icon color"
+            value={playerIconColor}
+            onChange={setPlayerIconColor}
           />
           <Title order={4}>Website Hotkeys</Title>
           <Group grow>

--- a/apps/overwolf/src/components/usePlayerPosition.ts
+++ b/apps/overwolf/src/components/usePlayerPosition.ts
@@ -7,6 +7,7 @@ import PositionMarker from 'ui/components/WorldMap//PositionMarker';
 import { useMap } from 'ui/utils/routes';
 import { useNavigate } from 'react-router-dom';
 import { findMapDetails, mapIsAeternumMap } from 'static';
+import { useSettings } from 'ui/contexts/SettingsContext';
 
 const divElement = leaflet.DomUtil.create('div', 'leaflet-player-position');
 
@@ -22,6 +23,7 @@ function usePlayerPosition({
   const [marker, setMarker] = useState<PositionMarker | null>(null);
   const map = useMap();
   const navigate = useNavigate();
+  const { playerIconColor } = useSettings();
 
   let playerPosition: Position | null = null;
   let playerMap: string | null = null;
@@ -49,7 +51,7 @@ function usePlayerPosition({
     if (!leafletMap || !playerPosition || !isOnSameWorld) {
       return;
     }
-    const icon = createPlayerIcon();
+    const icon = createPlayerIcon(playerIconColor);
     const newMarker = new PositionMarker(playerPosition.location, {
       icon,
       zIndexOffset: 9000,
@@ -61,7 +63,7 @@ function usePlayerPosition({
     return () => {
       newMarker.remove();
     };
-  }, [leafletMap, Boolean(playerPosition), isOnSameWorld]);
+  }, [leafletMap, Boolean(playerPosition), isOnSameWorld, playerIconColor]);
 
   useEffect(() => {
     if (

--- a/packages/ui/components/Settings/Settings.module.css
+++ b/packages/ui/components/Settings/Settings.module.css
@@ -6,16 +6,6 @@
   overflow: auto;
 }
 
-.label {
-  display: grid;
-  grid-template-columns: 50% 50%;
-  align-items: center;
-}
-
-.label input {
-  padding: 0;
-}
-
 .link button {
   padding: 0;
 }

--- a/packages/ui/components/Settings/Settings.tsx
+++ b/packages/ui/components/Settings/Settings.tsx
@@ -24,6 +24,8 @@ function Settings(): JSX.Element {
     setAdaptiveZoom,
     traceLineColor,
     setTraceLineColor,
+    playerIconColor,
+    setPlayerIconColor,
   } = useSettings();
 
   useEffect(() => {
@@ -87,6 +89,14 @@ function Settings(): JSX.Element {
           type="color"
           value={traceLineColor}
           onChange={(event) => setTraceLineColor(event.target.value)}
+        />
+      </label>
+      <label className={styles.label}>
+        Player icon color
+        <input
+          type="color"
+          value={playerIconColor}
+          onChange={(event) => setPlayerIconColor(event.target.value)}
         />
       </label>
       <label className={styles.label}>

--- a/packages/ui/components/Settings/Settings.tsx
+++ b/packages/ui/components/Settings/Settings.tsx
@@ -1,3 +1,11 @@
+import {
+  Checkbox,
+  ColorInput,
+  NumberInput,
+  Slider,
+  Text,
+  Title,
+} from '@mantine/core';
 import { useEffect } from 'react';
 import { useSettings } from '../../contexts/SettingsContext';
 import SupporterInput from '../SupporterInput/SupporterInput';
@@ -38,96 +46,68 @@ function Settings(): JSX.Element {
 
   return (
     <div className={styles.container}>
-      <h2>Settings</h2>
-      <h3>Map</h3>
-      <label className={styles.label}>
-        Marker size
-        <input
-          type="range"
-          value={markerSize}
-          onChange={(event) => setMarkerSize(+event.target.value)}
-          min={10}
-          max={80}
-        />
-      </label>
-      <label className={styles.label}>
-        Marker background
-        <input
-          type="checkbox"
-          checked={markerShowBackground}
-          onChange={(event) => setMarkerShowBackground(event.target.checked)}
-        />
-      </label>
-      <label className={styles.label}>
-        Region borders
-        <input
-          type="checkbox"
-          checked={showRegionBorders}
-          onChange={(event) => setShowRegionBorders(event.target.checked)}
-        />
-      </label>
-
-      <label className={styles.label}>
-        Show trace line
-        <input
-          type="checkbox"
-          checked={showTraceLines}
-          onChange={(event) => setShowTraceLines(event.target.checked)}
-        />
-      </label>
-      <label className={styles.label}>
-        Trace line length
-        <input
-          type="number"
-          value={maxTraceLines}
-          onChange={(event) => setMaxTraceLines(+event.target.value)}
-        />
-      </label>
-      <label className={styles.label}>
-        Trace line color
-        <input
-          type="color"
-          value={traceLineColor}
-          onChange={(event) => setTraceLineColor(event.target.value)}
-        />
-      </label>
-      <label className={styles.label}>
-        Player icon color
-        <input
-          type="color"
-          value={playerIconColor}
-          onChange={(event) => setPlayerIconColor(event.target.value)}
-        />
-      </label>
-      <label className={styles.label}>
-        Show Player Names
-        <input
-          type="checkbox"
-          checked={showPlayerNames}
-          onChange={(event) => setShowPlayerNames(event.target.checked)}
-        />
-      </label>
-      <label className={styles.label}>
-        Always show direction
-        <input
-          type="checkbox"
-          checked={alwaysShowDirection}
-          onChange={(event) => setAlwaysShowDirection(event.target.checked)}
-        />
-      </label>
-      <label className={styles.label}>
-        Adaptive Zoom
-        <input
-          type="checkbox"
-          checked={adaptiveZoom}
-          onChange={(event) => setAdaptiveZoom(event.target.checked)}
-        />
-      </label>
-      <h3>Hotkeys</h3>
-      <em>Hotkeys are configured in the Overwolf app</em>
-      <h3>GDPR</h3>
+      <Title order={4}>Map</Title>
+      <Text weight={500} size="sm">
+        Node size
+      </Text>
+      <Slider value={markerSize} onChange={setMarkerSize} min={10} max={80} />
+      <Checkbox
+        label="Node background"
+        description="The nodes have a background for better distinction to the background."
+        checked={markerShowBackground}
+        onChange={(event) => setMarkerShowBackground(event.target.checked)}
+      />
+      <Checkbox
+        label="Region borders"
+        checked={showRegionBorders}
+        description="You'll see thin lines on the map which indicates the regions."
+        onChange={(event) => setShowRegionBorders(event.target.checked)}
+      />
+      <Checkbox
+        label="Trace lines"
+        checked={showTraceLines}
+        description="Small dots will display the path you were walking. You will know where you have been to."
+        onChange={(event) => setShowTraceLines(event.target.checked)}
+      />
+      <NumberInput
+        label="Trace line length"
+        value={maxTraceLines}
+        onChange={setMaxTraceLines}
+        min={0}
+      />
+      <ColorInput
+        label="Trace line color"
+        value={traceLineColor}
+        onChange={setTraceLineColor}
+      />
+      <ColorInput
+        label="Player icon color"
+        value={playerIconColor}
+        onChange={setPlayerIconColor}
+      />
+      <Checkbox
+        label="Show Player Names"
+        checked={showPlayerNames}
+        description="Display the names of other players in your group next to their player icons."
+        onChange={(event) => setShowPlayerNames(event.target.checked)}
+      />
+      <Checkbox
+        label="Always show direction"
+        checked={alwaysShowDirection}
+        description="In addition to the app hotkey, you can always display the direction line."
+        onChange={(event) => setAlwaysShowDirection(event.target.checked)}
+      />
+      <Checkbox
+        label="Adaptive Zoom"
+        checked={adaptiveZoom}
+        description="The zoom level will change if you enter/leave a settlement."
+        onChange={(event) => setAdaptiveZoom(event.target.checked)}
+      />
+      <Title order={4}>Hotkeys</Title>
+      <Text fs="italic">Hotkeys are configured in the Overwolf app</Text>
+      <Title order={4}>GDPR</Title>
       <span id="ncmp-consent-link" className={styles.link} />
-      <h3>User</h3>
+      <Title order={4}>User</Title>
       <ResetDiscoveredNodes />
       <SupporterInput />
     </div>

--- a/packages/ui/components/WorldMap/playerIcon.ts
+++ b/packages/ui/components/WorldMap/playerIcon.ts
@@ -1,13 +1,13 @@
 import leaflet from 'leaflet';
 
-export const createPlayerIcon = (color = '#A7A7A7') =>
+export const createPlayerIcon = (color = '#FEFEFE', borderColor = '#A7A7A7') =>
   leaflet.divIcon({
     html: `
     <svg style="filter: drop-shadow(0px 0px 5px rgb(0 0 0)) drop-shadow(0px 0px 5px rgb(0 0 0))" width="32px" height="32px" viewBox="0 0 48 48">
-        <g stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
-            <path clip-rule="evenodd" fill="none" stroke="${color}" d="M24 44c11.046 0 20-8.954 20-20S35.046 4 24 4S4 12.954 4 24s8.954 20 20 20z"/>
-            <path fill="${color}" stroke="#${color}" d="M24 13l-7 21l7-5l7 5l-7-21z"/>
-        </g>
+      <g stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path clip-rule="evenodd" fill="none" stroke="${borderColor}" d="M24 44c11.046 0 20-8.954 20-20S35.046 4 24 4S4 12.954 4 24s8.954 20 20 20z"/>
+        <path fill="${color}" stroke="${color}" d="M24 13l-7 21l7-5l7 5l-7-21z"/>
+      </g>
     </svg>
     `,
     className: '',

--- a/packages/ui/components/WorldMap/playerIcon.ts
+++ b/packages/ui/components/WorldMap/playerIcon.ts
@@ -3,7 +3,12 @@ import leaflet from 'leaflet';
 export const createPlayerIcon = (color = '#A7A7A7') =>
   leaflet.divIcon({
     html: `
-    <svg style="filter: drop-shadow(0px 0px 5px rgb(0 0 0)) drop-shadow(0px 0px 5px rgb(0 0 0))" width="32px" height="32px" viewBox="0 0 48 48"><g stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path clip-rule="evenodd" fill="none" stroke="${color}" d="M24 44c11.046 0 20-8.954 20-20S35.046 4 24 4S4 12.954 4 24s8.954 20 20 20z"/><path fill="#FEFEFE" stroke="#FEFEFE" d="M24 13l-7 21l7-5l7 5l-7-21z"/></g></svg>
+    <svg style="filter: drop-shadow(0px 0px 5px rgb(0 0 0)) drop-shadow(0px 0px 5px rgb(0 0 0))" width="32px" height="32px" viewBox="0 0 48 48">
+        <g stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+            <path clip-rule="evenodd" fill="none" stroke="${color}" d="M24 44c11.046 0 20-8.954 20-20S35.046 4 24 4S4 12.954 4 24s8.954 20 20 20z"/>
+            <path fill="${color}" stroke="#${color}" d="M24 13l-7 21l7-5l7 5l-7-21z"/>
+        </g>
+    </svg>
     `,
     className: '',
     iconSize: [32, 32],

--- a/packages/ui/components/WorldMap/useGroupPositions.ts
+++ b/packages/ui/components/WorldMap/useGroupPositions.ts
@@ -15,7 +15,7 @@ function useGroupPositions(group: Group): void {
     [username: string]: PositionMarker;
   }>({});
 
-  const { showPlayerNames } = useSettings();
+  const { showPlayerNames, playerIconColor } = useSettings();
   const map = useMap();
 
   useEffect(() => {
@@ -55,7 +55,7 @@ function useGroupPositions(group: Group): void {
 
           if (!existingMarker) {
             marker = new PositionMarker(player.position!.location, {
-              icon: createPlayerIcon(colorHash.hex(username)),
+              icon: createPlayerIcon(playerIconColor, colorHash.hex(username)),
               zIndexOffset: 8999,
               pmIgnore: true,
             });
@@ -99,7 +99,7 @@ function useGroupPositions(group: Group): void {
       );
     Object.values(removeablePlayerMarkers).forEach((marker) => marker.remove());
     setPlayerMarkers(newPlayerMarkers);
-  }, [latestLeafletMap, group, map]);
+  }, [latestLeafletMap, group, map, playerIconColor]);
 }
 
 export default useGroupPositions;

--- a/packages/ui/components/WorldMap/usePlayerPosition.ts
+++ b/packages/ui/components/WorldMap/usePlayerPosition.ts
@@ -48,7 +48,8 @@ function usePlayerPosition({
   const traceDotsGroup = useMemo(() => new leaflet.LayerGroup(), []);
   const traceDots = useMemo<leaflet.Circle[]>(() => [], []);
 
-  const { showTraceLines, maxTraceLines, traceLineColor } = useSettings();
+  const { showTraceLines, maxTraceLines, traceLineColor, playerIconColor } =
+    useSettings();
   const map = useMap();
   const navigate = useNavigate();
 
@@ -96,7 +97,7 @@ function usePlayerPosition({
     if (!leafletMap || !playerPosition || !isOnSameWorld) {
       return;
     }
-    const icon = createPlayerIcon();
+    const icon = createPlayerIcon(playerIconColor);
     const newMarker = new PositionMarker(playerPosition.location, {
       icon,
       zIndexOffset: 9000,

--- a/packages/ui/components/WorldMap/usePlayerPosition.ts
+++ b/packages/ui/components/WorldMap/usePlayerPosition.ts
@@ -110,7 +110,7 @@ function usePlayerPosition({
     return () => {
       newMarker.remove();
     };
-  }, [leafletMap, Boolean(playerPosition), isOnSameWorld]);
+  }, [leafletMap, Boolean(playerPosition), isOnSameWorld, playerIconColor]);
 
   useEffect(() => {
     // @ts-ignore

--- a/packages/ui/contexts/SettingsContext.tsx
+++ b/packages/ui/contexts/SettingsContext.tsx
@@ -22,6 +22,8 @@ type SettingsContextValue = {
   setAdaptiveZoom: (adaptiveZoom: boolean) => void;
   traceLineColor: string;
   setTraceLineColor: (traceLineColor: string) => void;
+  playerIconColor: string;
+  setPlayerIconColor: (playerIconColor: string) => void;
   peerToPeer: boolean;
   setPeerToPeer: (peerToPeer: boolean) => void;
   ocr: boolean;
@@ -46,6 +48,8 @@ const SettingsContext = createContext<SettingsContextValue>({
   setAdaptiveZoom: () => undefined,
   traceLineColor: '#F78166',
   setTraceLineColor: () => undefined,
+  playerIconColor: '#A7A7A7',
+  setPlayerIconColor: () => undefined,
   peerToPeer: true,
   setPeerToPeer: () => undefined,
   ocr: false,
@@ -91,6 +95,10 @@ export function SettingsProvider({
     'trace-line-color',
     '#F78166'
   );
+  const [playerIconColor, setPlayerIconColor] = usePersistentState(
+    'player-icon-color',
+    '#A7A7A7'
+  );
   const [peerToPeer, setPeerToPeer] = usePersistentState('peer-to-peer', true);
   const [ocr, setOCR] = usePersistentState('ocr', false);
 
@@ -115,6 +123,8 @@ export function SettingsProvider({
         setAdaptiveZoom,
         traceLineColor,
         setTraceLineColor,
+        playerIconColor,
+        setPlayerIconColor,
         peerToPeer,
         setPeerToPeer,
         ocr,

--- a/packages/ui/contexts/SettingsContext.tsx
+++ b/packages/ui/contexts/SettingsContext.tsx
@@ -97,7 +97,7 @@ export function SettingsProvider({
   );
   const [playerIconColor, setPlayerIconColor] = usePersistentState(
     'player-icon-color',
-    '#A7A7A7'
+    '#FEFEFE'
   );
   const [peerToPeer, setPeerToPeer] = usePersistentState('peer-to-peer', true);
   const [ocr, setOCR] = usePersistentState('ocr', false);


### PR DESCRIPTION
Will by default choose the colour that is already used.

Users can now go into the settings and customise the colour.

![image](https://user-images.githubusercontent.com/11903234/204104364-843b8f05-ee66-4e78-8346-1f5499b7e760.png)

Future things to think about:
 - Making settings more managable / maintainable.
   - Maybe have collapsible subsections (player config, maker config, advanced - reset nodes, reset settings etc).
 - Add an option to reset all settings back to default (i.e delete them from local state).