### PR TITLE
Add optional glyph required field for glyph chests.

### DIFF
--- a/packages/static/src/mapFilters.ts
+++ b/packages/static/src/mapFilters.ts
@@ -87,6 +87,9 @@ export const mapFilters: FilterItem[] = [
     type: 'glyphChest',
     title: 'Glyph Chest',
     iconUrl: '/pois/chest_glyph.webp',
+    glyph: {
+      isRequired: false,
+    },
   },
   {
     category: 'chests',


### PR DESCRIPTION
Configure glyph chests to have optional glyph required property.

![image](https://user-images.githubusercontent.com/11903234/204104530-f80ddb1b-e98a-472f-9da6-c68f7d892eae.png)
